### PR TITLE
Miscellaneous, but also API reshape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-main: main.c coroutine.o
-	gcc -Wall -Wextra -ggdb -o main main.c coroutine.o
+cflags = -Wall -Wextra -ggdb
 
-coroutine.o: coroutine.c
-	gcc -Wall -Wextra -ggdb -c coroutine.c
+
+main: main.c coroutine.o
+	gcc $(cflags) -o main main.c coroutine.o
+
+coroutine.o: coroutine.c coroutine.h
+	gcc $(cflags) -c coroutine.c
 
 main_c3: main.c3 coroutine.o coroutine.c3
 	c3c compile main.c3 coroutine.c3 coroutine.o

--- a/coroutine.c3
+++ b/coroutine.c3
@@ -3,9 +3,9 @@ module coroutine;
 
 def CoroutineFn = fn void(void*);
 
-extern fn void init() @extern("coroutine_init");
+//extern fn void init() @extern("coroutine_init");
 extern fn void finish() @extern("coroutine_finish");
 extern fn void yield() @extern("coroutine_yield");
-extern fn void go(CoroutineFn f, void* arg = null) @extern("coroutine_go");
+extern fn void add(CoroutineFn f, void* arg = null) @extern("coroutine_add");
 extern fn usz id() @extern("coroutine_id");
 extern fn usz alive() @extern("coroutine_alive");

--- a/coroutine.h
+++ b/coroutine.h
@@ -1,10 +1,11 @@
 #ifndef COROUTINE_H_
 #define COROUTINE_H_
 
-void coroutine_init(void);
-void coroutine_finish(void);
+// void coroutine_init(void);
 void coroutine_yield(void);
-void coroutine_go(void (*f)(void*), void *arg);
+void coroutine_add(void (*f)(void*), void *arg);
+void coroutine_finish(void);
+
 size_t coroutine_id(void);
 size_t coroutine_alive(void);
 

--- a/main.c
+++ b/main.c
@@ -9,17 +9,18 @@ void counter(void *arg)
 {
     long int n = (long int)arg;
     for (int i = 0; i < n; ++i) {
-        printf("[%zu] %d\n", coroutine_id(), i);
+        printf("[%ld/%ld] %d\n", coroutine_id(), coroutine_alive(), i);
         coroutine_yield();
     }
 }
 
 int main()
 {
-    coroutine_init();
-        coroutine_go(&counter, (void*)5);
-        coroutine_go(&counter, (void*)10);
-        while (coroutine_alive() > 1) coroutine_yield();
-    coroutine_finish();
+    // Add the coroutines you want
+    coroutine_add(&counter, (void*)10);
+    coroutine_add(&counter, (void*)3);
+    // Yield to start the first coroutine
+    coroutine_yield();
+    printf("All of the coroutines reached their end\n");
     return 0;
 }


### PR DESCRIPTION
(This might be my first contribution to a C project)
- Makefile: added coroutine.h (saw ninja video)
- Free some memory
- Renamed coroutine_go to coroutine_add (kinda regret)
- No need to call coroutine_init and coroutine_finish from main
- We don't busyyield on the main
- If we are alone, we don't store and restore things
- Randomly added const somewhere
- Don't swap contexts?
  Nope: Bug introduced when co1 finishes before co2
- Sorry, added silly comments
- Tested on gcc: for us asm sticks with -O3 without need for volatile

- Let the coroutine know it's rbp (but useless)
- [probably don't merge this] Switched to reallocarray and aligned_alloc whatever that means: NOTE: aligned_alloc seems to be introduced in C11, but, I can't add -std=c11 or I get "assignment to 'Context *' from 'int'" upon reallocarray, after "implicit declaration of function 'reallocarray'" ofc

Thank you, this was really fun.