### PR TITLE
Add support for macOS + make architecture dependent section smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Make sure you have all the corresponding compilers for the languages.
 ## Supported platforms
 
 - Linux x86_64
+- macOS x86_64
 
 *More are planned in the future*
 

--- a/coroutine.c
+++ b/coroutine.c
@@ -103,7 +103,6 @@ void __attribute__((naked)) coroutine_yield(void)
 
 void __attribute__((naked)) coroutine_sleep_read(int fd)
 {
-    (void) fd;
     // @arch
     asm(
     "    pushq %rdi\n"
@@ -121,7 +120,6 @@ void __attribute__((naked)) coroutine_sleep_read(int fd)
 
 void __attribute__((naked)) coroutine_sleep_write(int fd)
 {
-    (void) fd;
     // @arch
     asm(
     "    pushq %rdi\n"
@@ -140,7 +138,6 @@ void __attribute__((naked)) coroutine_sleep_write(int fd)
 void __attribute__((naked)) coroutine_restore_context(void *rsp)
 {
     // @arch
-    (void)rsp;
     asm(
     "    movq %rdi, %rsp\n"
     "    popq %r15\n"


### PR DESCRIPTION
This PR adds support for macOS, where the main difference is that all functions have a leading underscore. I also made the target specific assembly section smaller by combining the yield functions in to one. This is possible since the order of the function arguments are the same.